### PR TITLE
fix(interpolate): escape regexp symbols

### DIFF
--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -1,16 +1,31 @@
 'use strict';
+const { compose, values, mapObjIndexed, reduce, replace, flip, call, take } = require('ramda');
 const curry = require('./curry');
 const { rejectNil } = require('./reject-nil');
-const { compose, values, mapObjIndexed, reduce, replace, flip, call } = require('ramda');
+const escapeStringRegexp = require('./utils/escape-regex');
+
+/**
+ * @private
+ * @type {Number}
+ */
+const MAX_SYMBOL_LENGTH = 512;
+
+/**
+ * @private
+ * @function
+ */
+const sanitizeSymbol = compose(escapeStringRegexp, take(MAX_SYMBOL_LENGTH));
 
 const replacer = compose(
   values,
-  mapObjIndexed((value, key) => replace(new RegExp(`{${key}}`, 'g'), value)),
+  mapObjIndexed((value, key) => replace(new RegExp(`{${sanitizeSymbol(key)}}`, 'g'), value)),
   rejectNil
 );
 
 /**
- * Replaces variables in a template enclosed by `{}`.
+ * Replaces variables in a template enclosed by `{}`. Variable names
+ * will be escaped for safe regular expression usage and, for safety reasons,
+ * cannot exceed `512` characters in length.
  *
  * @example
  *  interpolate('I am {name}', { name: 'Error' });

--- a/src/interpolate.test.js
+++ b/src/interpolate.test.js
@@ -45,3 +45,13 @@ test('should not replace values in the `template` that are not present in the `c
     })
   ).toBe('I am selling these fine {material} jackets!');
 });
+
+test('should escape symbols in the template for safe regular expression usage', () => {
+  expect(
+    interpolate('I am selling these {^it.description} {it/material$} {[it*item]}!', {
+      '^it.description': 'fine',
+      'it/material$': 'leather',
+      '[it*item]': 'jackets'
+    })
+  ).toBe('I am selling these fine leather jackets!');
+});

--- a/src/utils/escape-regex.js
+++ b/src/utils/escape-regex.js
@@ -1,0 +1,14 @@
+'use strict';
+const { replace, compose } = require('ramda');
+
+/**
+ * Escape `RegExp` special characters.
+ *
+ * @private
+ * @function
+ * @param {*} value Value to escape (will be coerced into a `String`).
+ * @returns {String} The escaped value, sanitized to be used in a regular expression.
+ */
+const escapeStringRegexp = compose(replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&'), String);
+
+module.exports = escapeStringRegexp;

--- a/src/utils/escape-regex.test.js
+++ b/src/utils/escape-regex.test.js
@@ -1,0 +1,12 @@
+'use strict';
+const escapeStringRegexp = require('./escape-regex');
+
+test('should escape special characters', () => {
+  expect(escapeStringRegexp('\\ ^ $ * + ? . ( ) | { } [ ]')).toEqual(
+    '\\\\ \\^ \\$ \\* \\+ \\? \\. \\( \\) \\| \\{ \\} \\[ \\]'
+  );
+});
+
+test('should escape `-` characters', () => {
+  expect(escapeStringRegexp('foo - bar')).toEqual('foo \\- bar');
+});


### PR DESCRIPTION
This bit me today.

Using characters that have a special meaning within a `RegExp` on template keys, such as `{my.var}`, would result in interpolated values not being replaced at all.

Also, restricting the length of keys seemed like a reasonable measure against potential DoS `RegExp` attacks. More info on that [here](https://github.com/nodesecurity/eslint-plugin-security/blob/master/docs/regular-expression-dos-and-node.md#regular-expression-dos-and-nodejs).

Great library, BTW ❤️.

**DISCLAIMER**: Escape `RegExp` string logic shamelessly stolen from https://github.com/sindresorhus/escape-string-regexp.