### PR TITLE
feat: update ramda dependency

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -9,7 +9,7 @@ jobs:
   jest:
     strategy:
       matrix:
-        version: ['0.26.1', '0.27.0', '0.27.1', '0.27.2', '0.28']
+        version: ['0.29']
     name: Unit test
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "tsd-jsdoc": "^2.5.0"
   },
   "peerDependencies": {
-    "ramda": ">=0.28.0"
+    "ramda": ">=0.29.0"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "move-file-cli": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",
-    "ramda": "^0.28.0",
+    "ramda": "^0.29.0",
     "replace-in-files-cli": "^2.0.0",
     "rimraf": "^5.0.0",
     "rollup": "^3.20.2",
@@ -115,7 +115,7 @@
     "tsd-jsdoc": "^2.5.0"
   },
   "peerDependencies": {
-    "ramda": ">=0.26.1"
+    "ramda": ">=0.28.0"
   },
   "engines": {
     "node": ">=12"

--- a/src/cast-array.js
+++ b/src/cast-array.js
@@ -14,6 +14,6 @@ import { unless, is, of } from 'ramda';
  * @returns {Array} An `Array` containing the given `value`
  *  or the same input if it was already an `Array`.
  */
-const castArray = unless(is(Array), of);
+const castArray = unless(is(Array), of(Array));
 
 export default castArray;

--- a/src/join-from.js
+++ b/src/join-from.js
@@ -20,7 +20,7 @@ import { rejectNil } from './reject-nil';
  *  `fns` with `separator`.
  */
 const joinFrom = curry(function joinFrom(separator, fns, elem) {
-  return applyTo(elem, compose(join(separator), rejectNil, ap(fns), of));
+  return applyTo(elem, compose(join(separator), rejectNil, ap(fns), of(Array)));
 });
 
 export default joinFrom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5533,10 +5533,10 @@ ramda@0.25.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
   integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
-ramda@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
-  integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
+ramda@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.0.tgz#fbbb67a740a754c8a4cbb41e2a6e0eb8507f55fb"
+  integrity sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
BREAKING CHANGE: upgrade ramda dependency and modifies the use of `of` function due to refactor introduced in https://github.com/ramda/ramda/pull/3272